### PR TITLE
More nickname entries in config.toml, and adding a cleanup script for config.toml

### DIFF
--- a/cleanup_config.toml.py
+++ b/cleanup_config.toml.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Lexicographically sort the nicknames in config.toml
+
+Dependencies:
+  Python 3.4+
+  The toml package (python -m pip install toml)
+
+Example: Dry run in default location
+  python cleanup_config.toml.py --dry-run
+
+Example: Overwrite config.toml in working directory
+  (Windows)   python cleanup_config.toml.py --dir=%CD%
+  (Unix-like) python cleanup_config.toml.py --dir=$PWD
+"""
+import os.path as path
+import sys
+
+from argparse import ArgumentParser, RawTextHelpFormatter
+from os.path import expanduser, realpath
+
+import toml
+
+CONFIG_TEMPLATE = """# Configuration file for ABV
+
+# Barcodes should be strings, because leading zeros are not allowed
+undoBarcode = "{undo}"
+redoBarcode = "{redo}"
+
+# Set location to cache brewery images for web menu. Do not use trailing slash. Defaults to ~/.abv/images
+#imageCachePath = /var/temp
+
+# Set location of config files. Do not use trailing slash. Defaults to ~/.abv
+#configPath = ~/etc/abv
+
+# Set the web root directory (directory containing the front page html and the static/ folder). Do not use trailing slash. Defaults to /srv/http
+#webRoot = ~/.abv/www
+
+{breweries}
+
+{beers}
+"""
+
+
+def fullpath(*args):
+    return realpath(path.join(*args))
+
+
+def parsed_args():
+    doc_lines = __doc__.strip().split('\n')
+    parser = ArgumentParser(description=doc_lines[0],
+                            epilog='\n'.join(doc_lines[1:]),
+                            formatter_class=RawTextHelpFormatter)
+    parser.add_argument('-d', '--dir',
+                        action='store',
+                        dest='dir',
+                        default=fullpath(expanduser('~'), '.abv'),
+                        help='directory containing config.toml (default: $HOME/.abv)')
+    parser.add_argument('--dry-run',
+                        dest='dry_run',
+                        action='store_const',
+                        const=True,
+                        default=False,
+                        help='prints the resulting config.toml file to stdout rather than overwriting')
+    args = parser.parse_args()
+    return args
+
+
+def unpack_table(toml, name):
+    # Format table title
+    title = '[{name}]\n'.format(name=name)
+    # Define a whitespace insertion method based on the longest key
+    longest = max([len(key) for key in toml[name]])
+    def align(str_):
+        return ' '*(longest-len(str_)+1)
+    # Lexicographically sort and whitespace-align table items
+    table = sorted(toml[name].items(), key=lambda x: x[0])
+    line = '"{key}"{ws}= "{val}"'
+    items = '\n'.join([line.format(key=key, ws=align(key), val=val) for key, val in table])
+    return title + items
+
+
+def toml_from_file(filepath):
+    try:
+        parsed_toml = toml.load(filepath)
+    except FileNotFoundError:
+        sys.exit('File not found: {}'.format(filepath))
+    return parsed_toml
+
+
+def clean_config(filepath):
+    parsed_toml = toml_from_file(filepath)
+    # Unpack known config settings
+    undo = parsed_toml['undoBarcode']
+    redo = parsed_toml['redoBarcode']
+    breweries = unpack_table(parsed_toml, 'breweryNicknames')
+    beers = unpack_table(parsed_toml, 'beerNicknames')
+    # Insert into config template
+    text = CONFIG_TEMPLATE.format(undo=undo,
+                                  redo=redo,
+                                  breweries=breweries,
+                                  beers=beers)
+    return text
+
+
+def main():
+    args = parsed_args()
+    filepath = fullpath(args.dir, 'config.toml')
+    text = clean_config(filepath)
+    if args.dry_run:
+        print(text)
+    else:
+        with open(filepath, mode='w', encoding='utf8') as file_:
+            file_.write(text)
+
+
+if __name__ == '__main__':
+    main()

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,8 @@
 # Configuration file for ABV
 
-undoBarcode = 9876543
-redoBarcode = 1234567
+# Barcodes should be strings, because leading zeros are not allowed
+undoBarcode = "036000374575"
+redoBarcode = "1234567"
 
 # Set location to cache brewery images for web menu. Do not use trailing slash. Defaults to ~/.abv/images
 #imageCachePath = /var/temp
@@ -13,12 +14,49 @@ redoBarcode = 1234567
 #webRoot = ~/.abv/www
 
 [breweryNicknames]
-"Lagunitas Brewing Company" = "Lagunitas"
-"Blue Moon Brewing Company" = "Blue Moon"
-"Deschutes Brewery" = "Deschutes"
-"Einstök Ölgerð" = "Einstök"
-"Sierra Nevada Brewing Co." = "Sierra Nevada"
+"10 Barrel Brewing Co."                    = "10 Barrel"
+"101 North Brewing Company"                = "101 North"
+"Abbaye Notre-Dame de Saint-Rémy"          = "Trappist Abbey of Rochefort"
+"Ace Cider (The California Cider Company)" = "Ace Cider"
+"AleSmith Brewing Company"                 = "AleSmith"
+"Anderson Valley Brewing Company"          = "Anderson Valley"
+"Ballast Point Brewing Company"            = "Ballast Point"
+"Bayerische Staatsbrauerei Weihenstephan"  = "Weihenstephaner"
+"Blue Moon Brewing Company"                = "Blue Moon"
+"Deschutes Brewery"                        = "Deschutes"
+"Dogfish Head Craft Brewery"               = "Dogfish Head"
+"Dust Bowl Brewing Company"                = "Dust Bowl"
+"Eel River Brewing Company"                = "Eel River"
+"Einstök Ölgerð"                           = "Einstök"
+"Epic Brewing Co. (Utah, Colorado)"        = "Epic Brewing"
+"Firestone Walker Brewing Company"         = "Firestone Walker"
+"HenHouse Brewing Company"                 = "HenHouse"
+"Jacob Leinenkugel Brewing Company"        = "Jacob Leinenkugel"
+"Kona Brewing Company"                     = "Kona"
+"Lagunitas Brewing Company"                = "Lagunitas"
+"Mother Earth Brewing Company"             = "Mother Earth"
+"New Belgium Brewing Company"              = "New Belgium"
+"North Coast Brewing Company"              = "North Coast"
+"Sierra Nevada Brewing Co."                = "Sierra Nevada"
+"Sudwerk Brewing Co."                      = "Sudwerk"
 
 [beerNicknames]
-"Anchor Steam Beer" = "Anchor Steam"
-"60 Minute IPA" = "60 Minute"
+"60 Minute IPA"                        = "60 Minute"
+"Ace - Dry Apple Craft Cider"          = "Dry Apple Craft Cider"
+"Aloha Sculpin Hazy IPA"               = "Aloha Sculpin"
+"Anchor Steam Beer"                    = "Anchor Steam"
+"Barney Flats Oatmeal Stout"           = "Barney Flats"
+"Black Butte Porter"                   = "Black Butte"
+"Fresh Squeezed IPA"                   = "Fresh Squeezed"
+"Hefeweizen Bavarian Wheat"            = "Bavarian Wheat"
+"Heroine IPA"                          = "Heroine"
+"Hop Henge Imperial IPA (2018)"        = "Hop Henge"
+"Monk's Café Flemish Sour Ale"         = "Monk's Café"
+"Organic California Blonde Ale"        = "California Blonde Ale"
+"Oude Geuze (Vieille)"                 = "Oude Geuze"
+"Sin-Tax Imperial Peanut Butter Stout" = "Sin-Tax Peanut Butter Stout"
+"Space Dust IPA"                       = "Space Dust"
+"Stone Enjoy By 01.01.19 Brut IPA"     = "Enjoy By"
+"Tart 'N Juicy Sour IPA"               = "Tart 'N Juicy"
+"Weihenstephaner Hefeweissbier"        = "Weihenstephaner"
+"Wildcide Hard Cider"                  = "Wildcide"


### PR DESCRIPTION
I added more nickname entries to config.toml, and made a new cleanup script to alphabetize and whitespace-align all of the nicknames.

Another minor change: the undo and redo barcodes are now strings. This should be preferred over integers, since the TOML spec does not allow for leading zeros in integers.