### PR TITLE
Feature/arbitrary-toml-parsing

### DIFF
--- a/cleanup_config.toml.py
+++ b/cleanup_config.toml.py
@@ -14,7 +14,7 @@ Example: Overwrite config.toml in working directory
   (Windows)   python cleanup_config.toml.py --dir=%CD%
   (Unix-like) python cleanup_config.toml.py --dir=$PWD
 """
-import os.path as path
+import os
 import sys
 
 from argparse import ArgumentParser, RawTextHelpFormatter
@@ -22,26 +22,9 @@ from os.path import expanduser, realpath
 
 import toml
 
-CONFIG_TEMPLATE = """# Configuration file for ABV
-
-# Barcodes should be strings, because leading zeros are not allowed
-undoBarcode = "{undo}"
-redoBarcode = "{redo}"
-
-# Set location of config files. Do not use trailing slash. Defaults to ~/.abv
-#configPath = ~/etc/abv
-
-# Set the web root directory (directory containing the front page html and the static/ folder). Do not use trailing slash. Defaults to /srv/http
-#webRoot = ~/.abv/www
-
-{breweries}
-
-{beers}
-"""
-
 
 def fullpath(*args):
-    return realpath(path.join(*args))
+    return realpath(os.path.join(*args))
 
 
 def parsed_args():
@@ -64,40 +47,56 @@ def parsed_args():
     return args
 
 
-def unpack_table(toml, name):
+def unpack_table(lines):
+    table_toml = toml.loads(''.join(lines))
+    name = list(table_toml)[0]
     # Format table title
     title = '[{name}]\n'.format(name=name)
     # Define a whitespace insertion method based on the longest key
-    longest = max([len(key) for key in toml[name]])
+    longest = max([len(key) for key in table_toml[name]])
     def align(str_):
         return ' '*(longest-len(str_)+1)
     # Lexicographically sort and whitespace-align table items
-    table = sorted(toml[name].items(), key=lambda x: x[0])
+    table = sorted(table_toml[name].items(), key=lambda x: x[0])
     line = '"{key}"{ws}= "{val}"'
     items = '\n'.join([line.format(key=key, ws=align(key), val=val) for key, val in table])
-    return title + items
+    return title + items + '\n\n'
 
 
-def toml_from_file(filepath):
-    try:
-        parsed_toml = toml.load(filepath)
-    except FileNotFoundError:
-        sys.exit('File not found: {}'.format(filepath))
-    return parsed_toml
+def parse_toml(lines):
+    final = []
+    inside_table = False
+    for line in lines:
+        if line.strip().startswith('#'):
+            if not inside_table:
+                final.append(line)
+            continue
+        elif line.strip().startswith('['):
+            if inside_table:
+                final.append(unpack_table(table_lines))
+            inside_table = True
+            table_lines = [line]
+            continue
+        elif line.strip().startswith('"') and inside_table:
+            table_lines.append(line)
+            continue
+        elif line.strip() == '':
+            if not inside_table:
+                final.append(line)
+            continue
+        else:
+            inside_table = False
+            final.append(line)
+    if inside_table:
+        final.append(unpack_table(table_lines))
+    text = ''.join(final)
+    return text.strip() + '\n'
 
 
 def clean_config(filepath):
-    parsed_toml = toml_from_file(filepath)
-    # Unpack known config settings
-    undo = parsed_toml['undoBarcode']
-    redo = parsed_toml['redoBarcode']
-    breweries = unpack_table(parsed_toml, 'breweryNicknames')
-    beers = unpack_table(parsed_toml, 'beerNicknames')
-    # Insert into config template
-    text = CONFIG_TEMPLATE.format(undo=undo,
-                                  redo=redo,
-                                  breweries=breweries,
-                                  beers=beers)
+    with open(filepath, mode='r', encoding='utf8') as file_:
+        lines = file_.readlines()
+    text = parse_toml(lines)
     return text
 
 

--- a/config.toml
+++ b/config.toml
@@ -62,5 +62,5 @@ redoBarcode = "1234567"
 "Wildcide Hard Cider"                  = "Wildcide"
 
 [styleNicknames]
-"Saison / Farmhouse Ale"                 = "Farmhouse Ale"
-"Shandy / Radler"                        = "Shandy"
+"Saison / Farmhouse Ale" = "Farmhouse Ale"
+"Shandy / Radler"        = "Shandy"

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"path"
+
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
-	"github.com/mitchellh/go-homedir"
 )
 
 var v *viper.Viper
@@ -10,29 +12,32 @@ var v *viper.Viper
 // New returns a preconfigured Viper configuration helper
 func New() (*viper.Viper, error) {
 	if v == nil {
-		v = viper.New()
-		v.SetConfigName("config")
-		home, err := homedir.Dir()
-		if err != nil {
-			return nil, err
-		}
-		v.AddConfigPath(home + "/.abv/")
-		v.AddConfigPath(".")
-
-		v.WatchConfig()
-
-		v.SetEnvPrefix("abv")
-		v.BindEnv("untappdId")
-		v.BindEnv("untappdSecret")
-
-		v.SetDefault("configPath", home + "/.abv")
-		v.SetDefault("webRoot", "/srv/http")
-		v.SetDefault("apiUrl", "localhost")
-
-		if err = v.ReadInConfig(); err != nil {
-			return nil, err
-		}
+		return newViper()
 	}
+	return v, nil
+}
 
+func newViper() (*viper.Viper, error) {
+	v = viper.New()
+	v.SetConfigName("config")
+	home, err := homedir.Dir()
+	if err != nil {
+		return nil, err
+	}
+	v.AddConfigPath(path.Join(home, ".abv"))
+	v.AddConfigPath(".")
+	v.WatchConfig()
+
+	v.SetEnvPrefix("abv")
+	v.BindEnv("untappdId")
+	v.BindEnv("untappdSecret")
+
+	v.SetDefault("configPath", path.Join(home, ".abv"))
+	v.SetDefault("webRoot", path.Join("srv", "http"))
+	v.SetDefault("apiUrl", "localhost")
+
+	if err = v.ReadInConfig(); err != nil {
+		return nil, err
+	}
 	return v, nil
 }


### PR DESCRIPTION
The cleanup script no longer has a template. It parses arbitrary toml, and even preserves comments and line order. The only thing it doesn't support is comments inside of tables (because the idea of sorting comments inside of a table doesn't really make sense anyways).

Also I got rid of that huge nested level inside of config.go, and added cross-platform path joining.