### PR TITLE
ŇḞÇ ňöŗṁàḷīʑéɖ ƫë×Ɨ ʍʴɑᴾƿïŋğ

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/bhutch29/abv/cache"
 	"github.com/bhutch29/abv/config"
 	"github.com/bhutch29/abv/model"
@@ -141,11 +143,16 @@ func refreshInventory() error {
 	fmt.Fprintf(view, "Total Beers: %d      Total Varieties: %d\n\n", total, variety)
 	for _, drink := range inventory {
 		//TODO: Make this more robust to handle arbitrary length Brand and Name strings
-		if len(drink.Name) < 30 {
+		nfcBytes := norm.NFC.Bytes([]byte(drink.Name))
+		nfcRunes := []rune(string(nfcBytes))
+		visualLen := len(nfcRunes)
+		if visualLen < 30 {
 			fmt.Fprintf(view, "%-4d%-35s%-30s\n", drink.Quantity, drink.Brand, drink.Name)
 		} else {
-			fmt.Fprintf(view, "%-4d%-35s%-30s\n", drink.Quantity, drink.Brand, drink.Name[:30])
-			fmt.Fprintf(view, "%-4s%-35s%-30s\n", "", drink.Name[30:], "")
+			const wsPad = "                                       " // strings.Repeat(" ", 39)
+			fmt.Printf("Hello, %8s\n", "pad")
+			fmt.Fprintf(view, "%-4d%-35s%-30s...\n", drink.Quantity, drink.Brand, string(nfcRunes[:30]))
+			fmt.Fprintf(view, "%s...%s\n", wsPad, string(nfcRunes[30:]))
 		}
 	}
 	return nil


### PR DESCRIPTION
NFC normalized text wrapping, for drink names that are too long. This should close #106 when merged.

Currently it can support name lengths of up to 60 characters, regardless of character set or diacritics, macrons, etc. It seems to work with most of the major language blocks, but it doesn't work with glitch text. I think this may be due to poor unicode support in either Windows command prompt or the font I've chosen, and not necessarily a bug on our side of things.

In the future we should think of a more robust solution that allows for arbitrary lengths of text, but for now we are limited to 60 characters which seems sufficient.