### PR TITLE
Bugfix/aurora-api-change

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -3,10 +3,11 @@ package main
 import (
 	"fmt"
 
-	"github.com/jroimartin/gocui"
-	aur "github.com/logrusorgru/aurora"
 	"strconv"
 	"strings"
+
+	"github.com/jroimartin/gocui"
+	aur "github.com/logrusorgru/aurora"
 )
 
 type key struct {
@@ -48,11 +49,12 @@ func initializekeys() {
 func generateKeybindString(quantity int) string {
 	var result string
 	for _, k := range keys {
-		if k.viewname == "" || k.viewname == input{
+		if k.viewname == "" || k.viewname == input {
 			if getKeyQuantity(k.shortkey) == quantity {
 				result = result + fmt.Sprintf("%s->%s ", aur.BgBlue(aur.Black(k.shortkey)), k.shortname)
 			} else {
-				result = result + fmt.Sprintf("%s->%s ", aur.BgGray(aur.Black(k.shortkey)), k.shortname)
+				const GrayLevel = 12
+				result = result + fmt.Sprintf("%s->%s ", aur.BgGray(GrayLevel, aur.Black(k.shortkey)), k.shortname)
 			}
 		}
 	}

--- a/keys.go
+++ b/keys.go
@@ -51,11 +51,10 @@ func generateKeybindString(quantity int) string {
 	for _, k := range keys {
 		if k.viewname == "" || k.viewname == input {
 			if getKeyQuantity(k.shortkey) == quantity {
-				result = result + fmt.Sprintf("%s->%s ", aur.BgBlue(aur.Black(k.shortkey)), k.shortname)
-			} else {
-				const GrayLevel = 12
-				result = result + fmt.Sprintf("%s->%s ", aur.BgGray(GrayLevel, aur.Black(k.shortkey)), k.shortname)
+				result += fmt.Sprintf("%s->%s ", aur.BgBlue(aur.Black(k.shortkey)), k.shortname)
+				continue
 			}
+			result += fmt.Sprintf("%s->%s ", aur.BgWhite(aur.Black(k.shortkey)), k.shortname)
 		}
 	}
 	return result
@@ -71,10 +70,10 @@ func getKeyQuantity(shortkey string) int {
 
 func configureKeys() error {
 	for _, key := range keys {
-		if err := g.SetKeybinding(key.viewname, key.key, gocui.ModNone, key.handler); err != nil {
+		err := g.SetKeybinding(key.viewname, key.key, gocui.ModNone, key.handler)
+		if err != nil {
 			return err
 		}
 	}
-
 	return nil
 }


### PR DESCRIPTION
The Aurora API changed for text with gray background. The old API only required 1 argument for text, while the new API adds an additional argument for the "level" (from 0 to 24, which I can only assume is dark to light). However, I cannot figure out the new BgGray command; no matter what level I supply it with it chooses a black background, which makes me suspicious that not only the API changed, but also some of the internals.

As a short term workaround, I am changing to white background which seems to be a more stable part of the API, and which I have not experienced any problems with.

In the future, I would like to vendor or version-control our dependencies. I can see these types of problems popping up intermittently.